### PR TITLE
reset scenario after wrong otp

### DIFF
--- a/CredentialProvider/core/CCredential.cpp
+++ b/CredentialProvider/core/CCredential.cpp
@@ -592,6 +592,7 @@ HRESULT CCredential::GetSerialization(
 				{
 					showErrorMessage(_privacyIDEA.getLastErrorMessage(), _privacyIDEA.getLastErrorCode());
 				}
+				_util.ResetScenario(this, _config->provider.pCredProvCredentialEvents);
 				*pcpgsr = CPGSR_NO_CREDENTIAL_NOT_FINISHED;
 			}
 		}


### PR DESCRIPTION
if two step is enabled, this will cause the CP to jump back to the first step
fixes #53 