### PR TITLE
Fix the viewing of domain users

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -81,7 +81,7 @@ NOTE: Sending the windows or an empty password can be used to trigger token type
 
 **excluded_account**
 
-Specify an account that should be excluded from 2FA. The format is required to be domain\username or computername\username.
+Specify an account that should be excluded from 2FA. The format is required to be ``domain\username`` or ``computername\username``.
 
 
 Disabling for specific scenarios


### PR DESCRIPTION
Small fix for docs.

The backslash in the domain username is not display in the
documentation, since it is used for escaping.

Use backticks to format this as code, so the backslash is
visisble.