### PR TITLE
fix reset command link

### DIFF
--- a/CppClientCore/CppClientCore/Endpoint.cpp
+++ b/CppClientCore/CppClientCore/Endpoint.cpp
@@ -113,6 +113,9 @@ void CALLBACK WinHttpStatusCallback(
 	__in  DWORD dwStatusInformationLength
 )
 {
+	UNREFERENCED_PARAMETER(hInternet);
+	UNREFERENCED_PARAMETER(dwContext);
+
 	long lStatus = 0;
 	if (lpvStatusInformation != nullptr)
 	{
@@ -212,9 +215,9 @@ string Endpoint::SendRequest(const string& endpoint, std::string sdata, const Re
 	// Specify an HTTP server.
 	if (hSession)
 	{
-		// Install the status callback function.
-
-		WINHTTP_STATUS_CALLBACK isCallback = WinHttpSetStatusCallback(hSession,
+		// Set the callback and optionally a port other than default https
+		WINHTTP_STATUS_CALLBACK isCallback = WinHttpSetStatusCallback(
+			hSession,
 			(WINHTTP_STATUS_CALLBACK)WinHttpStatusCallback,
 			WINHTTP_CALLBACK_FLAG_ALL_NOTIFICATIONS,
 			NULL);

--- a/CredentialProvider/CredentialProvider.vcxproj
+++ b/CredentialProvider/CredentialProvider.vcxproj
@@ -215,6 +215,7 @@
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
     <PostBuildEvent>
       <Command>

--- a/CredentialProvider/Utilities.cpp
+++ b/CredentialProvider/Utilities.cpp
@@ -422,6 +422,8 @@ HRESULT Utilities::SetScenario(
 	{
 		pCPCE->SetFieldState(pCredential, FID_SUBTEXT, CPFS_HIDDEN);
 	}
+	// Reset Link, optional
+	pCPCE->SetFieldState(pCredential, FID_COMMANDLINK, (_config->showResetLink ? CPFS_DISPLAY_IN_SELECTED_TILE : CPFS_HIDDEN));
 
 	return hr;
 }

--- a/CredentialProvider/core/CCredential.cpp
+++ b/CredentialProvider/core/CCredential.cpp
@@ -219,7 +219,7 @@ HRESULT CCredential::SetSelected(__out BOOL* pbAutoLogon)
 		wstring wszLastUser = wszEntry.substr(wszEntry.find(L"\\") + 1, wszEntry.length() - 1);
 		hr = _pCredProvCredentialEvents->SetFieldString(this, FID_USERNAME, wszLastUser.c_str());
 	}
-
+	
 	if (!_config->showResetLink)
 	{
 		hr = _pCredProvCredentialEvents->SetFieldState(this, FID_COMMANDLINK, CPFS_HIDDEN);
@@ -512,6 +512,7 @@ HRESULT CCredential::CommandLinkClicked(__in DWORD dwFieldID)
 	UNREFERENCED_PARAMETER(dwFieldID);
 	DebugPrint(__FUNCTION__);
 	_util.ResetScenario(this, _pCredProvCredentialEvents);
+	_privacyIDEA.StopPoll();
 	return S_OK;
 }
 

--- a/CredentialProvider/core/CProvider.cpp
+++ b/CredentialProvider/core/CProvider.cpp
@@ -117,7 +117,7 @@ HRESULT CProvider::SetUsageScenario(
 		}
 	}
 
-	DebugPrint("SetScenario result:");
+	DebugPrint("SetUsageScenario result:");
 	DebugPrint(hr);
 
 	return hr;
@@ -388,7 +388,6 @@ HRESULT CProvider::GetCredentialAt(
 
 	HRESULT hr = E_FAIL;
 	const CREDENTIAL_PROVIDER_USAGE_SCENARIO usage_scenario = _config->provider.cpu;
-
 
 	if (!_credential)
 	{

--- a/CredentialProviderFilter/CredentialProviderFilter.vcxproj
+++ b/CredentialProviderFilter/CredentialProviderFilter.vcxproj
@@ -132,6 +132,7 @@
       <MapExports>false</MapExports>
       <TargetMachine>MachineX64</TargetMachine>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
     <PostBuildEvent>
       <Command>


### PR DESCRIPTION
Some small fixes: 

* Resetting the login now stops the polling for push authentications
* Fixed the displaying of the reset command link
* Added /LTCG to linker options
* Some formatting