### PR TITLE
Feature: password_seeable Registry Key

### DIFF
--- a/CredentialProvider/Configuration.cpp
+++ b/CredentialProvider/Configuration.cpp
@@ -131,6 +131,8 @@ void Configuration::Load()
 	twoStepSendPassword = rr.GetBool(L"two_step_send_password");
 	usernamePassword = rr.GetBool(L"username_password");
 
+	passwordSeeable = rr.GetBool(L"password_seeable");
+
 	// Set locales files path from registry
 	localesPath = rr.GetWString(L"locales_path");
 

--- a/CredentialProvider/Configuration.h
+++ b/CredentialProvider/Configuration.h
@@ -149,6 +149,9 @@ public:
 	bool hideFirstStepResponseError = false;
 	bool noDefault = false;
 
+	// Bool to set enable/disable the button show password in password field
+	bool passwordSeeable = false;
+
 	WindowsInfo windowsVersion;
 
 	bool pushAuthenticationSuccess = false;

--- a/CredentialProvider/core/CCredential.cpp
+++ b/CredentialProvider/core/CCredential.cpp
@@ -531,6 +531,28 @@ HRESULT CCredential::GetSubmitButtonValue(
 	return E_INVALIDARG;
 }
 
+// GetFieldOptions - Function display "eye" button in paswword field 
+HRESULT CCredential::GetFieldOptions(
+    DWORD dwFieldID,
+    _Out_ CREDENTIAL_PROVIDER_CREDENTIAL_FIELD_OPTIONS* pcpcfo)
+{
+    *pcpcfo = CPCFO_NONE;
+
+    if (_config->passwordSeeable)  // verification Registry Key "password_seeable"
+    {
+        if (dwFieldID == FID_PASSWORD
+            || dwFieldID == FID_OTP
+            || dwFieldID == FID_FIDO_PIN
+            || dwFieldID == FID_NEW_PASS_1
+            || dwFieldID == FID_NEW_PASS_2)
+        {
+            *pcpcfo = CPCFO_ENABLE_PASSWORD_REVEAL;
+        }
+    }
+
+    return S_OK;
+}
+
 // Sets the value of a field which can accept a string as a value.
 // This is called on each keystroke when a user types into an edit field.
 HRESULT CCredential::SetStringValue(

--- a/CredentialProvider/core/CCredential.h
+++ b/CredentialProvider/core/CCredential.h
@@ -40,7 +40,8 @@
 #define ZERO(NAME) \
 	SecureZeroMemory(NAME, sizeof(NAME))
 
-class CCredential : public IConnectableCredentialProviderCredential
+class CCredential : public IConnectableCredentialProviderCredential, 
+                    public ICredentialProviderCredentialWithFieldOptions
 {
 public:
 	// IUnknown
@@ -66,6 +67,7 @@ public:
 		{
 			QITABENT(CCredential, ICredentialProviderCredential), // IID_ICredentialProviderCredential
 			QITABENT(CCredential, IConnectableCredentialProviderCredential), // IID_IConnectableCredentialProviderCredential
+			QITABENT(CCredential, ICredentialProviderCredentialWithFieldOptions),
 			{ 0 },
 		};
 
@@ -104,6 +106,12 @@ public:
 		__in NTSTATUS ntsSubstatus,
 		__deref_out_opt PWSTR* ppwszOptionalStatusText,
 		__out CREDENTIAL_PROVIDER_STATUS_ICON* pcpsiOptionalStatusIcon) override;
+
+	// ICredentialProviderCredentialWithFieldOptions
+	// Enables the password reveal button (the "eye" icon) on password fields.
+	// Requires Windows 8+ and the ICredentialProviderCredentialWithFieldOptions interface.
+	IFACEMETHODIMP GetFieldOptions(__in DWORD dwFieldID,
+		__out CREDENTIAL_PROVIDER_CREDENTIAL_FIELD_OPTIONS* pcpcfo);
 
 public:
 	// IConnectableCredentialProviderCredential 

--- a/WiXSetup/Product.wxs
+++ b/WiXSetup/Product.wxs
@@ -259,6 +259,11 @@
 		<Property Id="PASSKEY_FIRST_STEP">
 			<RegistrySearch Id="SearchPasskeyFirstStep" Root="HKLM" Key="SOFTWARE\$(var.Manufacturer)\$(var.SimpleProductName)" Name="passkey_first_step" Win64="$(var.Win64)" Type="raw" />
 		</Property>
+            <!-- Registry Password seaable -->
+		<Property Id="PASSWORD_SEEABLE" Value="0">
+			<RegistrySearch Id="SearchPasswordSeeable" Root="HKLM" Key="SOFTWARE\$(var.Manufacturer)\$(var.SimpleProductName)" Name="password_seeable" Win64="$(var.Win64)" Type="raw" />	
+		</Property>
+
 		<Directory Id="TARGETDIR" Name="SourceDir">
 			<?if $(var.Configuration) = Debug ?>
 			<?if $(var.Platform) = x64 ?>
@@ -388,6 +393,8 @@
 						<RegistryValue Name="autologon_username" Type="string" Value="[AUTOLOGON_USERNAME]" />
 						<RegistryValue Name="autologon_domain" Type="string" Value="[AUTOLOGON_DOMAIN]" />
 						<RegistryValue Name="autologon_password" Type="string" Value="[AUTOLOGON_PASSWORD]" />
+
+						<RegistryValue Name="password_seeable" Type="string" Value="[PASSWORD_SEEABLE]" />
 					</RegistryKey>
 					<RemoveRegistryKey Root="HKLM" Key="SOFTWARE\$(var.Manufacturer)\$(var.SimpleProductName)" Action="removeOnUninstall" />
 				</Component>


### PR DESCRIPTION
feat: add password_seeable registry key to toggle password reveal button

Implement ICredentialProviderCredentialWithFieldOptions to enable the Windows password reveal (eye) button on password fields.

The feature is controlled by a new registry key following the existing REG_SZ boolean pattern used throughout the credential provider:
  HKLM\SOFTWARE\NetKnights GmbH\PrivacyIDEA-CP\password_seeable
  "1" = reveal button enabled | "0" / absent = disabled (default)

Changes:
- CCredential.h: inherit ICredentialProviderCredentialWithFieldOptions, declare GetFieldOptions(), register QITABENT
- CCredential.cpp: implement GetFieldOptions() gated on _config->passwordSeeable; applies CPCFO_ENABLE_PASSWORD_REVEAL to FID_PASSWORD, FID_OTP, FID_FIDO_PIN, FID_NEW_PASS_1, FID_NEW_PASS_2
- Configuration.h: add bool passwordSeeable{ false }
- Configuration.cpp: read password_seeable via RegistryReader::GetBool()
- Product.wxs: add registry search, default property (0) and write on install