### PR TITLE
Issue 235

### DIFF
--- a/CredentialProvider/core/CCredential.cpp
+++ b/CredentialProvider/core/CCredential.cpp
@@ -1958,7 +1958,11 @@ HRESULT CCredential::FIDOAuthentication(IQueryContinueWithStatus* pqcws)
 			{
 				if (hr == FIDO_ERR_TX) hr = FIDO_DEVICE_ERR_TX;
 				_lastStatus = hr;
-				SetMode(Mode::PRIVACYIDEA);
+				// On PIN errors, keep user on PIN screen to retry. On other errors, go back to OTP.
+				if (hr != FIDO_ERR_PIN_INVALID && hr != FIDO_ERR_PIN_AUTH_BLOCKED)
+				{
+					SetMode(Mode::PRIVACYIDEA);
+				}
 				return hr;
 			}
 		}
@@ -2008,7 +2012,11 @@ HRESULT CCredential::FIDOAuthentication(IQueryContinueWithStatus* pqcws)
 			PIError("Signing failed with error: " + to_string(hr));
 			if (hr == FIDO_ERR_TX) hr = FIDO_DEVICE_ERR_TX;
 			_lastStatus = hr;
-			if (hr != FIDO_ERR_NO_CREDENTIALS) SetMode(Mode::PRIVACYIDEA);
+			// On PIN errors, keep user on PIN screen to retry. On other errors, go back to OTP.
+			if (hr != FIDO_ERR_NO_CREDENTIALS && hr != FIDO_ERR_PIN_INVALID && hr != FIDO_ERR_PIN_AUTH_BLOCKED)
+			{
+				SetMode(Mode::PRIVACYIDEA);
+			}
 			return E_FAIL;
 		}
 


### PR DESCRIPTION
Fix: Allow PIN retry on same FIDO2 challenge after failed authentication

Problem:
When FIDO2 authentication failed due to an invalid PIN, the application would return to the OTP screen instead of keeping the user on the PIN entry screen.

This forced users to:
- Go back to the OTP screen
- Re-validate the OTP
- Retry FIDO2 authentication with a new server challenge

Additionally, when retrying FIDO2 after returning to OTP, the system would reuse the stale challenge and fail with "Response didn't match challenge".

Solution:
Distinguish between PIN errors and other FIDO2 errors to provide better UX:

- PIN ERRORS (FIDO_ERR_PIN_INVALID, FIDO_ERR_PIN_AUTH_BLOCKED):
  - User remains on PIN entry screen and can retry immediately
  - Improved user experience without compromising security

- OTHER ERRORS:
  - User returns to OTP screen as before

Changes:
- Online FIDO2 authentication: Keep PIN mode for PIN-related errors
- Offline FIDO2 authentication: Apply same logic for consistency

Files Changed:
- CredentialProvider/core/CCredential.cpp
  - FIDOAuthentication(): Online error handling (~line 2011)
  - FIDOAuthentication(): Offline error handling (~line 1961)